### PR TITLE
Improve doc.pl behavior: faster redirect, shorter URLs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,1 +1,5 @@
 Options -Indexes
+
+# Slightly shorter redirect links
+RewriteEngine On
+RewriteRule ^puzzleboss/doc/([^/]*)$ /puzzleboss/bin/doc.pl?pid=$1 [L]

--- a/bin/doc.pl
+++ b/bin/doc.pl
@@ -5,7 +5,7 @@ use warnings;
 use lib qw(.);
 
 BEGIN {
-    require 'pblib.cfg';
+  require 'pblib.cfg';
 }
 
 use CGI ':standard';
@@ -13,36 +13,32 @@ use CGI ':standard';
 use PB::API;
 use PB::Config;
 
-
-my $html_start = <<"EOF";
-Content-type: text/html
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-
-EOF
-
-print $html_start;
 my $pid = 0;
 
-if (param('pid')){
-	$pid = param('pid');
-}else{
-	print "</head><body>No Puzzle-ID parameter supplied</body></html>";
-	exit;
+if (param('pid')) {
+  $pid = param('pid');
+} else {
+  print "<!doctype html><html><body>No Puzzle-ID parameter supplied</body></html>";
+  exit;
 }
-
 
 my $puzzlerow_ref = PB::API::get_puzzle($pid);
 my %puzzlerow = %$puzzlerow_ref;
 
 my $doc_link = $puzzlerow{'drive_uri'};
 
+if ($doc_link) {
+  print "Location: $doc_link\n\n";
+  exit;
+}
+
+print "Content-type: text/html\n\n";
+print "<!doctype html><html><head>\n";
 print "<meta http-equiv='refresh' content='1;".$doc_link."'>";
 print "</head><body>";
 
-print "You should be automatically redirected, otherwise: <a href='".$doc_link."'>google doc for puzzle</a><br>"; 
+print "You should be automatically redirected, otherwise: ";
+print "<a href='".$doc_link."'>google doc for puzzle</a><br>";
 
 print "</body></html>";
 


### PR DESCRIPTION
Instead of having `doc.pl` handle redirects through the `<meta>` HTML tag, let's pass the redirect in via the response header. `Location: http://www.google.com` will just send the user there without waiting a second to reload, which should be nicer for puzzlers.

I also added some logic to the `.htaccess`, which should let us write `wind-up-birds.org/puzzleboss/doc/FooBar` and it'll load as `wind-up-birds.org/puzzleboss/bin/doc.pl?pid=FooBar`