### PR TITLE
Stop announcing empty xyzlocs

### DIFF
--- a/lib/PB/API.pm
+++ b/lib/PB/API.pm
@@ -390,9 +390,11 @@ sub update_puzzle_part {
     if ($part eq "xyzloc") {
         my $puzzref    = get_puzzle($id);
         my $channel_id = $puzzref->{'slack_channel_id'};
-        discord_say_something($channel_id,
-            "ATTENTION: puzzle $id is being worked on at $val",
-        );
+        if ($val ne "") {
+            discord_say_something($channel_id,
+                "ATTENTION: puzzle $id is being worked on at $val",
+            );
+        }
     }
 
     if ($part eq "status" && $val eq "Needs eyes") {


### PR DESCRIPTION
Let's prevent this:

![image](https://user-images.githubusercontent.com/1410509/104718613-23a82680-56f9-11eb-88a9-1a624660c722.png)
